### PR TITLE
Add a shell eval blind command injection check

### DIFF
--- a/activeScan++.py
+++ b/activeScan++.py
@@ -82,7 +82,7 @@ class CodeExec(IScannerCheck):
         self._payloads = {
             # Exploits shell command injection into '$input' on linux and "$input" on windows:
             # and CVE-2014-6271, CVE-2014-6278
-            'any': ['"&ping -n $time localhost&\'`sleep $time`\'', '() { :;}; /bin/sleep $time', '() { _; } >_[$$($$())] { /bin/sleep $time; }'],
+            'any': ['"&ping -n $time localhost&\'`sleep $time`\'', '() { :;}; /bin/sleep $time', '() { _; } >_[$$($$())] { /bin/sleep $time; }', '$$(sleep $time)'],
             'php': [],
             'perl': [],
             'ruby': ['|sleep $time & ping -n $time localhost'],


### PR DESCRIPTION
My suggested addition is just a simple blind injection check using shell evaluation. I've found this useful at times when an injection point has relatively strict validation.