### PR TITLE
Adds three checks

### DIFF
--- a/activeScan++.py
+++ b/activeScan++.py
@@ -49,6 +49,11 @@ class BurpExtender(IBurpExtender):
         helpers = callbacks.getHelpers()
         callbacks.setExtensionName("activeScan++")
 
+        #gracefully skip checks requiring Collaborator if it's disabled
+        collab_options = callbacks.saveConfigAsJson("project_options.misc.collaborator_server")
+        if '"type":"none"' in collab_options:
+            debug_msg("Collaborator not enabled; skipping checks that require it")
+        
         callbacks.registerScannerCheck(PerHostScans())
         callbacks.registerScannerCheck(PerRequestScans())
 
@@ -57,7 +62,7 @@ class BurpExtender(IBurpExtender):
             callbacks.registerScannerCheck(SuspectTransform())
             callbacks.registerScannerCheck(JetLeak())
             callbacks.registerScannerCheck(SimpleFuzz())
-            callbacks.registerScannerCheck(Solr())
+            if not '"type":"none"' in collab_options: callbacks.registerScannerCheck(Solr())
             callbacks.registerScannerCheck(EdgeSideInclude())
 
         print "Successfully loaded activeScan++ v" + VERSION

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -188,8 +188,8 @@ class PerRequestScans(IScannerCheck):
 
 
 # Based on exploit at https://github.com/chrisjd20/cve-2017-9805.py
-# Tested against https://dev.northpolewonderland.com (SANS Holiday Hack Challenge 2017)
-# Tested against https://pentesterlab.com/exercises/s2-052
+# Tested against https://dev.northpolechristmastown.com/orders.xhtml (SANS Holiday Hack Challenge 2017)
+# Tested against system at https://pentesterlab.com/exercises/s2-052
     def doStruts_2017_9805_Scan(self, basePair):
         global callbacks, helpers
 


### PR DESCRIPTION
Added checks for two additional Struts2 vulns and XXE in a POST body.

Note: the XXE vuln requires sending a POST request.  There doesn't seem to be any built-in method for this conversion, so code turns the request into a string, trims out "GET" and inserts "POST."  It seems to work well enough, but -

**KNOWN ISSUE:** it gets grumpy when scanning a request with UTF-16 text.

There's probably a better way?

-Chris