### PR TITLE
Trivial addition of app-site association check

### DIFF
--- a/activeScan++.py
+++ b/activeScan++.py
@@ -96,6 +96,7 @@ class PerHostScans(IScannerCheck):
 
         '/.git/config': '[core]',
         '/server-status': 'Server uptime',
+        '/.well-known/apple-app-site-association': 'applinks',
     }
 
 


### PR DESCRIPTION
Similar to robots.txt, easy to add, and not included in Burp as per https://portswigger.net/kb/issues

See: https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2019/april/apples_app_site_association_the_new_robots_txt/
and portswiggers own: https://portswigger.net/daily-swig/apples-app-site-association-creates-info-leak-risk