### PR TITLE
Log4j typo and severity adjustments

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -15,6 +15,8 @@ Designed to add minimal network overhead, it identifies application behaviour th
     <li>CVE-2014-6271/CVE-2014-6278 'shellshock' and CVE-2015-2080, CVE-2017-5638, CVE-2017-12629</li>
 </ul>
 
+<p>It also provides insertion points for HTTP basic authentication.</p>
+
 <p>To invoke these checks, just run a normal active scan.</p>
 
 <p>The host header checks tamper with the host header, which may result in requests being routed to different applications on the same host.

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -21,5 +21,3 @@ Designed to add minimal network overhead, it identifies application behaviour th
 Exercise caution when running this scanner against applications in a shared hosting environment.</p>
 
 <p>This extension requires Burp Suite Professional version 1.6 or later and Jython 2.5 or later standalone.</p>
-
-<p>The source for this extension can be found <a href="https://github.com/albinowax/ActiveScanPlusPlus">here</a>.</p>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -12,7 +12,7 @@ Designed to add minimal network overhead, it identifies application behaviour th
 
 <ul>
     <li>Blind code injection via expression language, Ruby's open() and Perl's open()</li>
-    <li>CVE-2014-6271/CVE-2014-6278 'shellshock' and CVE-2015-2080</li>
+    <li>CVE-2014-6271/CVE-2014-6278 'shellshock' and CVE-2015-2080, CVE-2017-5638, CVE-2017-12629</li>
 </ul>
 
 <p>To invoke these checks, just run a normal active scan.</p>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -3,6 +3,7 @@ Designed to add minimal network overhead, it identifies application behaviour th
 
 <ul>
     <li>Potential host header attacks (password reset poisoning, cache poisoning, DNS rebinding)</li>
+    <li>Edge side includes</li>
     <li>XML input handling</li>
     <li>Suspicious input transformation (eg 7*7 =&gt; '49', \x41\x41 =&gt; 'AA')</li>
     <li>Passive-scanner issues that only occur during fuzzing (install the 'Error Message Checks' extension for maximum effectiveness)</li>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -13,7 +13,7 @@ Designed to add minimal network overhead, it identifies application behaviour th
 
 <ul>
     <li>Blind code injection via expression language, Ruby's open() and Perl's open()</li>
-    <li>CVE-2014-6271/CVE-2014-6278 'shellshock' and CVE-2015-2080, CVE-2017-5638, CVE-2017-12629</li>
+    <li>CVE-2014-6271/CVE-2014-6278 'shellshock' and CVE-2015-2080, CVE-2017-5638, CVE-2017-12629, CVE-2018-11776</li>
 </ul>
 
 <p>It also provides insertion points for HTTP basic authentication.</p>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,25 @@
+<p>ActiveScan++ extends Burp Suite's active and passive scanning capabilities.
+Designed to add minimal network overhead, it identifies application behaviour that may be of interest to advanced testers:</p>
+
+<ul>
+    <li>Potential host header attacks (password reset poisoning, cache poisoning, DNS rebinding)</li>
+    <li>XML input handling</li>
+    <li>Suspicious input transformation (eg 7*7 =&gt; '49', \x41\x41 =&gt; 'AA')</li>
+    <li>Passive-scanner issues that only occur during fuzzing (install the 'Error Message Checks' extension for maximum effectiveness)</li>
+</ul>
+
+<p>It also adds checks for the following issues:</p>
+
+<ul>
+    <li>Blind code injection via expression language, Ruby's open() and Perl's open()</li>
+    <li>CVE-2014-6271/CVE-2014-6278 'shellshock' and CVE-2015-2080</li>
+</ul>
+
+<p>To invoke these checks, just run a normal active scan.</p>
+
+<p>The host header checks tamper with the host header, which may result in requests being routed to different applications on the same host.
+Exercise caution when running this scanner against applications in a shared hosting environment.</p>
+
+<p>This extension requires Burp Suite Professional version 1.6 or later and Jython 2.5 or later standalone.</p>
+
+<p>The source for this extension can be found <a href="https://github.com/albinowax/ActiveScanPlusPlus">here</a>.</p>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -24,3 +24,5 @@ Designed to add minimal network overhead, it identifies application behaviour th
 Exercise caution when running this scanner against applications in a shared hosting environment.</p>
 
 <p>This extension requires Burp Suite Professional version 1.6 or later and Jython 2.5 or later standalone.</p>
+
+<p>Copyright &copy; 2014-2022 PortSwigger Ltd.</p>

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.20
-SerialVersion: 17
+ScreenVersion: 1.0.21
+SerialVersion: 18
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.14
-SerialVersion: 10
+ScreenVersion: 1.0.15
+SerialVersion: 11
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,7 +3,7 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.16
-SerialVersion: 12
+SerialVersion: 13
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,9 +3,10 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.21d
-SerialVersion: 21
+SerialVersion: 22
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle
 ShortDescription: Extends Burp's active and passive scanning capabilities.
 EntryPoint: activeScan++.py
+BuildCommand: 

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,7 +3,7 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.16
-SerialVersion: 14
+SerialVersion: 15
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,7 +3,7 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.16
-SerialVersion: 13
+SerialVersion: 14
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.16
+ScreenVersion: 1.0.18
 SerialVersion: 15
 MinPlatformVersion: 0
 ProOnly: True

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.21
-SerialVersion: 18
+ScreenVersion: 1.0.21b
+SerialVersion: 19
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.19
-SerialVersion: 16
+ScreenVersion: 1.0.20
+SerialVersion: 17
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,6 +1,7 @@
 Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
+RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.13
 SerialVersion: 9
 MinPlatformVersion: 0

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.21b
-SerialVersion: 19
+ScreenVersion: 1.0.21c
+SerialVersion: 20
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,7 +3,7 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.22
-SerialVersion: 22
+SerialVersion: 23
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.15
-SerialVersion: 11
+ScreenVersion: 1.0.16
+SerialVersion: 12
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,7 +3,7 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.14
-SerialVersion: 9
+SerialVersion: 10
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.18
-SerialVersion: 15
+ScreenVersion: 1.0.19
+SerialVersion: 16
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.21d
+ScreenVersion: 1.0.22
 SerialVersion: 22
 MinPlatformVersion: 0
 ProOnly: True

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,11 +3,11 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.22
-SerialVersion: 24
+SerialVersion: 25
 MinPlatformVersion: 0
 ProOnly: True
 Author: James 'albinowax' Kettle, PortSwigger
 ShortDescription: Extends Burp's active and passive scanning capabilities.
 EntryPoint: activeScan++.py
 BuildCommand: 
-SupportedProducts: Pro, Enterprise 
+SupportedProducts: Pro 

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,10 +3,11 @@ ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
 ScreenVersion: 1.0.22
-SerialVersion: 23
+SerialVersion: 24
 MinPlatformVersion: 0
 ProOnly: True
-Author: James Kettle
+Author: James 'albinowax' Kettle, PortSwigger
 ShortDescription: Extends Burp's active and passive scanning capabilities.
 EntryPoint: activeScan++.py
 BuildCommand: 
+SupportedProducts: Pro, Enterprise 

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.21c
-SerialVersion: 20
+ScreenVersion: 1.0.21d
+SerialVersion: 21
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.13
+ScreenVersion: 1.0.14
 SerialVersion: 9
 MinPlatformVersion: 0
 ProOnly: True

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,10 @@
+Uuid: 3123d5b5f25c4128894d97ea1acc4976
+ExtensionType: 2
+Name: Active Scan++
+ScreenVersion: 1.0.13
+SerialVersion: 9
+MinPlatformVersion: 0
+ProOnly: True
+Author: James Kettle
+ShortDescription: Extends Burp's active and passive scanning capabilities.
+EntryPoint: activeScan++.py

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To invoke these checks, just run a normal active scan.
 The host header checks tamper with the host header, which may result in requests being routed to different applications on the same host. Exercise caution when running this scanner against applications in a shared hosting environment.
     
 #### Changelog:
+**1.0.23 20211210**
+ - Log4Shell (CVE-2021-44228)
+ 
 **1.0.22 20210325**
   - Detect interesting OAuth endpoints. 
   - For further details, please refer to [Hidden OAuth Attack Vectors](https://portswigger.net/research/hidden-oauth-attack-vectors)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ To invoke these checks, just run a normal active scan.
 The host header checks tamper with the host header, which may result in requests being routed to different applications on the same host. Exercise caution when running this scanner against applications in a shared hosting environment.
     
 #### Changelog:
+**1.0.22 20210325**
+  - Detect interesting OAuth endpoints. 
+  - For further details, please refer to [Hidden OAuth Attack Vectors](https://portswigger.net/research/hidden-oauth-attack-vectors)
+  
 **1.0.21 20190322**
   - Detect Rails file disclosure (CVE-2019-5418)
 

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     print "Failed to load dependencies. This issue may be caused by using the unstable Jython 2.7 beta."
 
-VERSION = "1.0.21"
+VERSION = "1.0.21b"
 FAST_MODE = False
 DEBUG = False
 callbacks = None

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -114,12 +114,13 @@ class PerHostScans(IScannerCheck):
                 # prevent false positives by tweaking the URL and confirming the expected string goes away
                 baseline = self.fetchURL(basePair, url[:-1])
                 if expect not in safe_bytes_to_string(baseline.getResponse()):
+                    severity = 'Low' if '/.well-known/' in url else 'High'
                     issues.append(
                         CustomScanIssue(basePair.getHttpService(), helpers.analyzeRequest(attack).getUrl(),
                                         [attack, baseline],
                                         'Interesting response',
                                         "The response to <b>"+html_encode(url)+"</b> contains <b>'"+html_encode(expect)+"'</b><br/><br/>This may be interesting. Here's a clue why: <b>"+html_encode(reason)+"</b>",
-                                        'Firm', 'High')
+                                        'Firm', severity)
                     )
 
 
@@ -721,7 +722,7 @@ class Log4j(IScannerCheck):
         interactions = collab.fetchAllCollaboratorInteractions()
         if interactions:
             return [CustomScanIssue(attack.getHttpService(), helpers.analyzeRequest(attack).getUrl(), [attack],
-                                    'Log4Shell (CVE-2021-44228)',
+                                    'Log4j (CVE-2021-44228)',
                                     "The application appears to be running a version of log4j vulnerable to RCE. ActiveScan++ sent a reference to an external file, and received a pingback from the server.<br/><br/>" +
                                     "To investigate, use the manual collaborator client. It may be possible to escalate this vulnerability into RCE. Please refer to https://www.lunasec.io/docs/blog/log4j-zero-day/ for further information",
                                     'Firm', 'High')]

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -193,8 +193,9 @@ class PerRequestScans(IScannerCheck):
 
         (ignore, req) = setHeader(basePair.getRequest(), 'Accept', '../../../../../../../../../../../../../e*c/h*s*s{{', True)
         attack = callbacks.makeHttpRequest(basePair.getHttpService(), req)
-        if '127.0.0.1' in safe_bytes_to_string(attack.getResponse()):
-
+        response = safe_bytes_to_string(attack.getResponse())
+        body_delim = '\r\n\r\n'
+        if body_delim in response and '127.0.0.1' in response.split(body_delim, 1)[1]:
             # avoid false positives caused by burp's own scanchecks containing '127.0.0.1'
             try:
                 collabLocation = callbacks.createBurpCollaboratorClientContext().getCollaboratorServerLocation()

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -436,6 +436,11 @@ class CodeExec(IScannerCheck):
             if self._attack(basePair, insertionPoint, payload, 11)[0] > max(baseTime + 6, 10):
                 debug_msg("Suspicious delay detected. Confirming it's consistent...")
                 (dummyTime, dummyAttack) = self._attack(basePair, insertionPoint, payload, 0)
+
+                if dummyAttack.getResponse() is None:
+                    debug_msg('Received empty response to baseline request - abandoning attack')
+                    break
+
                 if (dummyTime < baseTime + 4):
                     (timer, attack) = self._attack(basePair, insertionPoint, payload, 11)
                     if timer > max(dummyTime + 6, 10):
@@ -539,6 +544,8 @@ class CustomScanIssue(IScanIssue):
 # misc utility methods
 
 def launchPassiveScan(attack):
+    if attack.getResponse() is None:
+        return
     service = attack.getHttpService()
     using_https = service.getProtocol() == 'https'
     callbacks.doPassiveScan(service.getHost(), service.getPort(), using_https, attack.getRequest(),

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     print "Failed to load dependencies. This issue may be caused by using the unstable Jython 2.7 beta."
 
-VERSION = "1.0.21b"
+VERSION = "1.0.21c"
 FAST_MODE = False
 DEBUG = False
 callbacks = None

--- a/activeScan++.py
+++ b/activeScan++.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     print "Failed to load dependencies. This issue may be caused by using the unstable Jython 2.7 beta."
 
-VERSION = "1.0.15"
+VERSION = "1.0.16"
 FAST_MODE = False
 DEBUG = False
 callbacks = None


### PR DESCRIPTION
- fix copy/paste error for Log4j
- Low severity finding instead of High for .well-known files